### PR TITLE
Update to allow hackathon to be demonstrated

### DIFF
--- a/Gemfile-maze-runner
+++ b/Gemfile-maze-runner
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.10.1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'integration/hackathon-2024'

--- a/features/hackathon.feature
+++ b/features/hackathon.feature
@@ -1,0 +1,70 @@
+Feature: Plain add tab to metadata
+
+Scenario Outline: Metadata can be added to a report using add_tab
+  Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
+  When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/add_tab.rb"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
+  And the event "metaData.additional_metadata.foo" equals "foo"
+  And the event "metaData.additional_metadata.bar.0" equals "b"
+  And the event "metaData.additional_metadata.bar.1" equals "a"
+  And the event "metaData.additional_metadata.bar.2" equals "r"
+  And the last event is available via the data access api
+  And the pipeline event payload field "metaData.additional_metadata.foo" equals "foo"
+  And the pipeline event payload field "metaData.additional_metadata.bar.0" equals "b"
+  And the pipeline event payload field "metaData.additional_metadata.bar.1" equals "a"
+  And the pipeline event payload field "metaData.additional_metadata.bar.2" equals "r"
+
+  Examples:
+  | initiator               |
+  | handled_before_notify   |
+  | handled_block           |
+  | unhandled_before_notify |
+  | handled_on_error        |
+  | unhandled_on_error      |
+
+Scenario Outline: Metadata can be added to an existing tab using add_tab
+  Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
+  When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/add_tab_existing.rb"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
+  And the event "metaData.additional_metadata.foo" equals "foo"
+  And the event "metaData.additional_metadata.bar.0" equals "b"
+  And the event "metaData.additional_metadata.bar.1" equals "a"
+  And the event "metaData.additional_metadata.bar.2" equals "r"
+  And the event "metaData.additional_metadata.foobar.first" equals "foo"
+  And the event "metaData.additional_metadata.foobar.then" equals "bar"
+  And the last event is available via the data access api
+  And the pipeline event payload field "metaData.additional_metadata.foo" equals "foo"
+  And the pipeline event payload field "metaData.additional_metadata.bar.0" equals "b"
+  And the pipeline event payload field "metaData.additional_metadata.bar.1" equals "a"
+  And the pipeline event payload field "metaData.additional_metadata.bar.2" equals "r"
+  And the pipeline event payload field "metaData.additional_metadata.foobar.first" equals "foo"
+  And the pipeline event payload field "metaData.additional_metadata.foobar.then" equals "bar"
+
+  Examples:
+  | initiator               |
+  | handled_before_notify   |
+  | handled_block           |
+  | unhandled_before_notify |
+  | handled_on_error        |
+  | unhandled_on_error      |
+
+Scenario Outline: Metadata can be overwritten using add_tab
+  Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
+  When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/add_tab_override.rb"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
+  And the event "metaData.additional_metadata.foo" equals "foo"
+  And the event "metaData.additional_metadata.bar" equals "bar"
+  And the last event is available via the data access api
+  And the pipeline event payload field "metaData.additional_metadata.foo" equals "foo"
+  And the pipeline event payload field "metaData.additional_metadata.bar" equals "bar"
+
+  Examples:
+  | initiator               |
+  | handled_before_notify   |
+  | handled_block           |
+  | unhandled_before_notify |
+  | handled_on_error        |
+  | unhandled_on_error      |

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -56,6 +56,7 @@ Maze.hooks.before_all do
 end
 
 Maze.hooks.before do
+  $api_key = ENV["MAZE_REPEATER_API_KEY"] if ENV["MAZE_REPEATER_API_KEY"]
   Maze::Runner.environment["BUGSNAG_API_KEY"] = $api_key
 
   host = running_in_docker? ? "maze-runner" : current_ip


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->

## Summary by Sourcery

Enable demonstration of hackathon features by adding support for metadata manipulation in reports and enhancing environment configuration.

New Features:
- Introduce a new feature to add metadata to reports using the add_tab method in the hackathon.feature file.

Enhancements:
- Enhance the environment setup by conditionally setting the $api_key from the MAZE_REPEATER_API_KEY environment variable.

Tests:
- Add new test scenarios in hackathon.feature to verify metadata addition, modification, and overwriting using the add_tab method.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the dependency to use the `bugsnag-maze-runner` from the `integration/hackathon-2024` branch instead of a tagged version and add new feature scenarios in `hackathon.feature` to demonstrate metadata addition and modification, along with an update to load a Maze repeater API key if available.

### Why are these changes being made?

These changes enable the demonstration of specific hackathon features by testing different scenarios of metadata modification using the Bugsnag notifier. Switching to the specific branch allows incorporating the latest functionalities needed for the hackathon, while the added scenarios validate these capabilities in the given context. Additionally, setting the API key from the environment ensures flexibility and security in the testing setup.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->